### PR TITLE
add mixnet ansible playbooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,11 @@ panda/server/cmd/panda_server/panda_server
 reunion/servers/reunion_katzenpost_server/reunion_katzenpost_server
 server/cmd/server/server
 server_plugins/cbor_plugins/echo-go/echo_server
+
+.idea
+ansible/infra/.terraform
+ansible/infra/.terraform.lock.hcl
+ansible/infra/terraform.tfstate
+ansible/infra/terraform.tfstate.backup
+tmp
+ansible/katzenpost-ansible.pem

--- a/ansible/hosts_builder.ini
+++ b/ansible/hosts_builder.ini
@@ -1,0 +1,2 @@
+[katzenpost_builder]
+35.171.28.135 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu

--- a/ansible/hosts_mixnet.ini
+++ b/ansible/hosts_mixnet.ini
@@ -1,0 +1,11 @@
+[mix_nodes]
+3.82.243.136 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+54.175.238.40 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+54.81.131.190 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+[provider_nodes]
+44.201.89.205 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+44.212.65.132 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+[dirauth_nodes]
+34.207.164.245 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+3.83.254.26 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+34.230.71.85 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu

--- a/ansible/infra/aws_setup.sh
+++ b/ansible/infra/aws_setup.sh
@@ -1,0 +1,10 @@
+#export AWS_PROFILE=personal
+#
+#aws s3 ls
+#aws ec2 describe-instances
+
+#terraform init
+#terraform plan -var-file="terraform.tfvars"
+terraform apply -var-file="terraform.tfvars" --auto-approve
+
+cp hosts_builder.ini hosts_mixnet.ini ..

--- a/ansible/infra/hosts_builder.ini
+++ b/ansible/infra/hosts_builder.ini
@@ -1,0 +1,2 @@
+[katzenpost_builder]
+35.171.28.135 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu

--- a/ansible/infra/hosts_mixnet.ini
+++ b/ansible/infra/hosts_mixnet.ini
@@ -1,0 +1,11 @@
+[mix_nodes]
+3.82.243.136 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+54.175.238.40 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+54.81.131.190 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+[provider_nodes]
+44.201.89.205 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+44.212.65.132 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+[dirauth_nodes]
+34.207.164.245 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+3.83.254.26 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu
+34.230.71.85 ansible_ssh_private_key_file=katzenpost-ansible.pem ansible_ssh_user=ubuntu

--- a/ansible/infra/main.tf
+++ b/ansible/infra/main.tf
@@ -1,0 +1,112 @@
+provider "aws" {
+  region = var.region
+  profile = var.profile
+}
+
+resource "aws_security_group" "ssh_and_internal" {
+  name        = "ssh_and_internal"
+  description = "Allow SSH, tcp on 8080 and internal VPC traffic"
+
+  # Allow SSH from anywhere
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow tcp traffic on port 8080 from anywhere
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow all traffic within the VPC
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = true
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "katzenpost_builder" {
+  ami           = var.ami
+  instance_type = "t2.medium"
+  key_name      = var.key_name
+  security_groups = [aws_security_group.ssh_and_internal.name]
+
+  tags = {
+    Name = "katzenpost-builder"
+  }
+}
+
+resource "aws_instance" "mix_nodes" {
+  count         = var.mix_nodes_count
+  ami           = var.ami
+  instance_type = "t2.micro"
+  key_name      = var.key_name
+  security_groups = [aws_security_group.ssh_and_internal.name]
+
+  tags = {
+    Name = "mix-node-${count.index}"
+    Role = "MixNode"
+  }
+}
+
+resource "aws_instance" "provider_nodes" {
+  count         = var.provider_nodes_count
+  ami           = var.ami
+  instance_type = "t2.micro"
+  key_name      = var.key_name
+  security_groups = [aws_security_group.ssh_and_internal.name]
+
+  tags = {
+    Name = "provider-node-${count.index}"
+    Role = "ProviderNode"
+  }
+}
+
+resource "aws_instance" "dirauth_nodes" {
+  count         = var.dirauth_nodes_count
+  ami           = var.ami
+  instance_type = "t2.micro"
+  key_name      = var.key_name
+  security_groups = [aws_security_group.ssh_and_internal.name]
+
+  tags = {
+    Name = "dirauth-node-${count.index}"
+    Role = "DirauthNode"
+  }
+}
+
+resource "local_file" "ansible_hosts_mixnet" {
+  content = <<-EOF
+[mix_nodes]
+${join("\n", formatlist("%s ansible_ssh_private_key_file=${var.key_name}.pem ansible_ssh_user=ubuntu", aws_instance.mix_nodes[*].public_ip))}
+[provider_nodes]
+${join("\n", formatlist("%s ansible_ssh_private_key_file=${var.key_name}.pem ansible_ssh_user=ubuntu", aws_instance.provider_nodes[*].public_ip))}
+[dirauth_nodes]
+${join("\n", formatlist("%s ansible_ssh_private_key_file=${var.key_name}.pem ansible_ssh_user=ubuntu", aws_instance.dirauth_nodes[*].public_ip))}
+EOF
+
+  filename = "${path.module}/hosts_mixnet.ini"
+}
+
+resource "local_file" "ansible_hosts_builder" {
+  content = <<-EOF
+[katzenpost_builder]
+${aws_instance.katzenpost_builder.public_ip} ansible_ssh_private_key_file=${var.key_name}.pem ansible_ssh_user=ubuntu
+EOF
+
+  filename = "${path.module}/hosts_builder.ini"
+}

--- a/ansible/infra/outputs.tf
+++ b/ansible/infra/outputs.tf
@@ -1,0 +1,16 @@
+output "mix_nodes_ips" {
+  value = aws_instance.mix_nodes[*].public_ip
+}
+
+output "provider_nodes_ips" {
+  value = aws_instance.provider_nodes[*].public_ip
+}
+
+output "dirauth_nodes_ips" {
+  value = aws_instance.dirauth_nodes[*].public_ip
+}
+
+output "katzenpost_builder_public_ip" {
+  value = aws_instance.katzenpost_builder.public_ip
+  description = "The public IP address of the Katzenpost builder instance."
+}

--- a/ansible/infra/terraform.tfvars
+++ b/ansible/infra/terraform.tfvars
@@ -1,0 +1,7 @@
+region = "us-east-1"
+ami = "ami-080e1f13689e07408"
+key_name = "katzenpost-ansible"
+profile = "personal"
+mix_nodes_count = 3
+provider_nodes_count = 2
+dirauth_nodes_count = 3

--- a/ansible/infra/variables.tf
+++ b/ansible/infra/variables.tf
@@ -1,0 +1,39 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "profile" {
+    description = "AWS profile"
+    type        = string
+    default     = "personal"
+}
+
+variable "ami" {
+  description = "AMI ID for the instances"
+  type        = string
+}
+
+variable "key_name" {
+  description = "SSH key pair name"
+  type        = string
+}
+
+variable "mix_nodes_count" {
+  description = "Number of mix nodes"
+  type        = number
+  default     = 3
+}
+
+variable "provider_nodes_count" {
+  description = "Number of provider nodes"
+  type        = number
+  default     = 2
+}
+
+variable "dirauth_nodes_count" {
+  description = "Number of dirauth nodes"
+  type        = number
+  default     = 3
+}

--- a/ansible/playbooks/build_and_configure.yml
+++ b/ansible/playbooks/build_and_configure.yml
@@ -1,0 +1,234 @@
+---
+- name: Build and Configure Katzenpost
+  hosts: katzenpost_builder
+  become: yes
+  environment:
+    GOROOT: /usr/local/go
+    GOPATH: "{{ ansible_env.HOME }}/go"
+    GOFLAGS: "-buildvcs=false"
+    PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin:{{ ansible_env.HOME }}/go/bin"
+  vars:
+    go_version: "1.21.3"
+    go_tarball: "go{{ go_version }}.linux-amd64.tar.gz"
+    go_download_url: "https://go.dev/dl/{{ go_tarball }}"
+    go_checksum: "1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8"
+    project_dir: "/opt/katzenpost"
+    configs_dir: "voting_mixnet"
+    dependencies: [ git, build-essential, zip ]
+    files_dir:
+
+  tasks:
+    - name: Load configuration variables from config.yml
+      include_vars:
+        file: config.yml
+        name: config
+    - name: Ensure artifacts directories exist
+      file:
+        path: "./artifacts"
+        state: directory
+
+    - name: Install required dependencies
+      apt:
+        name: "{{ dependencies }}"
+        state: present
+        update_cache: yes
+
+    - name: Setup Go environment
+      block:
+        - name: Download and extract Go tarball
+          get_url:
+            url: "{{ go_download_url }}"
+            dest: "/tmp/{{ go_tarball }}"
+            checksum: "sha256:{{ go_checksum }}"
+        - name: Extract Go tarball
+          ansible.builtin.unarchive:
+            src: "/tmp/{{ go_tarball }}"
+            dest: /usr/local
+            remote_src: yes
+            creates: "/usr/local/go/bin/go"
+        - name: Set Go environment paths
+          blockinfile:
+            path: /etc/profile.d/katzenpost.sh
+            block: |
+              export GOROOT=/usr/local/go
+              export GOPATH=$HOME/go
+              export GOFLAGS="-buildvcs=false"
+              export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
+            create: yes
+      notify: Refresh shell environment
+    - name: Clone and build Katzenpost components
+      block:
+        - name: Clone Katzenpost repository
+          git:
+            repo: "https://github.com/katzenpost/katzenpost.git"
+            dest: "{{ project_dir }}"
+            version: main
+            clone: yes
+            update: yes
+        - name: Build Katzenpost server components
+          shell: |
+            source /etc/profile.d/katzenpost.sh
+            cd "{{ project_dir }}"
+            make all
+          args:
+            executable: /bin/bash
+        - name: Build additional Katzenpost components
+          shell: |
+            source /etc/profile.d/katzenpost.sh
+            cd {{ project_dir }}/{{ item.path }}
+            go build -trimpath -ldflags "{{ item.ldflags }}"
+          loop:
+            - { path: "memspool/server/cmd/memspool", ldflags: "-buildid= -X github.com/katzenpost/katzenpost/core/epochtime.WarpedEpoch=true -X github.com/katzenpost/katzenpost/server/internal/pki.WarpedEpoch=true -X github.com/katzenpost/katzenpost/minclient/pki.WarpedEpoch=true" }
+            - { path: "panda/server/cmd/panda_server", ldflags: "-buildid= -X github.com/katzenpost/katzenpost/core/epochtime.WarpedEpoch=true -X github.com/katzenpost/katzenpost/server/internal/pki.WarpedEpoch=true -X github.com/katzenpost/katzenpost/minclient/pki.WarpedEpoch=true" }
+          args:
+            executable: /bin/bash
+
+    - name: Prepare directory and Copy build artifacts
+      block:
+        - name: Prepare directory for build artifacts
+          file:
+            path: "/home/ubuntu/bin"
+            state: directory
+          become: yes
+        - name: Copy build artifacts to a common directory
+          copy:
+            src: "{{ item.src }}"
+            dest: "/home/ubuntu/bin/{{ item.dest }}"
+            remote_src: yes
+          loop:
+            - { src: "{{ project_dir }}/server/cmd/server/server", dest: "server" }
+            - { src: "{{ project_dir }}/authority/cmd/voting/voting", dest: "voting" }
+            - { src: "{{ project_dir }}/ping/ping", dest: "ping" }
+            - { src: "{{ project_dir }}/memspool/server/cmd/memspool/memspool", dest: "memspool" }
+            - { src: "{{ project_dir }}/panda/server/cmd/panda_server/panda_server", dest: "panda_server" }
+          become: yes
+    - name: Build and Transfer Build Artifacts
+      block:
+        - name: Zip the bin directory on the remote host
+          shell: cd /home/ubuntu && zip -r bin.zip bin
+          args:
+            executable: /bin/bash
+          become: yes
+        - name: Fetch the zip file to the local machine
+          fetch:
+            src: "/home/ubuntu/bin.zip"
+            dest: "./artifacts/bin.zip"
+            flat: yes
+        - name: Unzip the bin directory locally
+          command: unzip -o "./artifacts/bin.zip" -d "./artifacts"
+          delegate_to: localhost
+          run_once: true
+          become: false
+    - name: generate Configuration of Katzenpost Network
+      block:
+        - name: Generate network configurations with genconfig
+          shell: |
+            mkdir -p "{{ configs_dir }}"
+            {{ project_dir }}/genconfig/genconfig \
+              -v \
+              -n {{ config.mix_count }} \
+              -p {{ config.provider_count }} \
+              -nv {{ config.dirauth_count }} \
+              -sr {{ config.sr }} \
+              -mu {{ config.mu }} \
+              -muMax {{ config.muMax }} \
+              -lP {{ config.lP }} \
+              -lPMax {{ config.lPMax }} \
+              -lL {{ config.lL }} \
+              -lLMax {{ config.lLMax }} \
+              -lD {{ config.lD }} \
+              -lDMax {{ config.lDMax }} \
+              -lM {{ config.lM }} \
+              -lMMax {{ config.lMMax }} \
+              -UserForwardPayloadLength {{ config.UserForwardPayloadLength }} \
+              -nike "{{ config.nike }}" \
+              -kem "{{ config.kem }}" \
+              -o "./{{ configs_dir }}" \
+              -b "/{{ configs_dir }}" \
+              -P {{ config.base_port }} \
+              -a "{{ config.bind_addr }}" \
+              -log_level {{ config.log_level }}
+          args:
+            executable: /bin/bash
+        # this task block updates the IP addresses in the generated configuration files
+        - name: Transfer and Execute Configuration Scripts
+          block:
+            - name: Copy hosts_mixnet.ini to builder host
+              copy:
+                src: ../hosts_mixnet.ini
+                dest: /home/ubuntu/hosts_mixnet.ini
+              become: yes
+            - name: Copy update_address.py to builder host
+              copy:
+                src: ../scripts/update_address.py
+                dest: /home/ubuntu/update_address.py
+              become: yes
+            - name: Execute update_address.py on builder host
+              command: python3 /home/ubuntu/update_address.py
+              args:
+                chdir: /home/ubuntu
+              become: yes
+        - name: Archive and Transfer Configuration Files
+          block:
+            - name: zip config files without including the parent 'home/ubuntu' directory
+              shell: cd /home/ubuntu && zip -r {{ configs_dir }}.zip {{ configs_dir }}
+              args:
+                executable: /bin/bash
+              register: zip_output
+              become: yes
+            - name: Copy config files to local machine
+              fetch:
+                src: "/home/ubuntu/{{ configs_dir }}.zip"
+                dest: "./artifacts/{{ configs_dir }}.zip"
+                flat: yes
+            - name: Unzip config files locally
+              command: unzip -o "./artifacts/{{ configs_dir }}.zip" -d "./artifacts"
+              delegate_to: localhost
+              run_once: true
+              become: false
+    - name: Distribute Public Key Infrastructure (PKI) Files
+      block:
+        - name: Find all *.public.pem files in voting_mixnet
+          ansible.builtin.find:
+            paths: "/home/ubuntu/{{ configs_dir }}"
+            patterns: "*.public.pem"
+            recurse: yes
+          register: public_pem_files
+        - name: Create directory structure for mixnet_pki
+          file:
+            path: "{{ project_dir }}/mixnet_pki/{{ item.path | regex_replace('^/home/ubuntu/' + configs_dir + '/', '') | regex_replace('/[^/]+$', '') }}"
+            state: directory
+          loop: "{{ public_pem_files.files }}"
+          loop_control:
+            label: "{{ item.path }}"
+          become: yes
+        - name: Copy found *.public.pem files to mixnet_pki directory on remote host
+          ansible.builtin.copy:
+            src: "{{ item.path }}"
+            dest: "{{ project_dir }}/mixnet_pki/{{ item.path | regex_replace('^/home/ubuntu/' + configs_dir + '/', '') }}"
+            remote_src: yes
+          loop: "{{ public_pem_files.files }}"
+          loop_control:
+            label: "{{ item.path }}"
+          become: yes
+        - name: Zip mixnet_pki directory on remote host
+          shell: cd "{{ project_dir }}" && zip -r mixnet_pki.zip mixnet_pki
+          args:
+            executable: /bin/bash
+          become: yes
+          register: zip_mixnet_pki_output
+        - name: Copy mixnet_pki.zip to local machine
+          fetch:
+            src: "{{ project_dir }}/mixnet_pki.zip"
+            dest: "./artifacts/mixnet_pki.zip"
+            flat: yes
+        - name: Unzip mixnet_pki directory locally
+          command: unzip -o "./artifacts/mixnet_pki.zip" -d "./artifacts"
+          delegate_to: localhost
+          run_once: true
+          become: false
+  handlers:
+    - name: Refresh shell environment
+      shell: source /etc/profile.d/katzenpost.sh
+      args:
+        executable: /bin/bash

--- a/ansible/playbooks/config.yml
+++ b/ansible/playbooks/config.yml
@@ -1,0 +1,26 @@
+# node_counts
+mix_count: 3
+provider_count: 2
+dirauth_count: 3
+
+# generate config params
+sr: 0
+mu: 0.005
+muMax: 1000
+lP: 0.001
+lPMax: 1000
+lL: 0.0005
+lLMax: 1000
+lD: 0.0005
+lDMax: 3000
+lM: 0.0005
+lMMax: 100
+UserForwardPayloadLength: 2000
+nike: "x25519"
+kem: ""
+net_name: "voting_mixnet"
+#  DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL"
+log_level: "INFO"
+base_port: 30000
+# update this to your public IP addresses in all the generated files
+bind_addr: "127.0.0.1"

--- a/ansible/playbooks/deploy_mixnet.yml
+++ b/ansible/playbooks/deploy_mixnet.yml
@@ -1,0 +1,58 @@
+- name: Load global configuration
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Load configuration from external file
+      include_vars:
+        file: config.yml
+        name: config
+
+- name: Common setup for all nodes
+  hosts: all
+  become: true
+  strategy: free
+  tasks:
+    - name: Include common setup tasks
+      include_tasks: roles/common/tasks/main.yml
+
+- name: Deploy Directory Authority Voting Nodes
+  hosts: dirauth_nodes
+  become: true
+  vars:
+    base_dir: "/opt/katzenpost"
+    dirauth_count: "{{ config.dirauth_count }}"
+    artifacts_dir: "{{ playbook_dir }}/artifacts"
+  strategy: free
+  tasks:
+    - name: Include Directory Authority setup tasks
+      include_tasks: roles/dirauth/tasks/setup.yml
+    - name: Include Directory Authority run tasks
+      include_tasks: roles/dirauth/tasks/run.yml
+
+- name: Deploy Provider Nodes
+  hosts: provider_nodes
+  become: true
+  vars:
+    base_dir: "/opt/katzenpost"
+    provider_count: "{{ config.provider_count }}"
+    artifacts_dir: "{{ playbook_dir }}/artifacts"
+  strategy: free
+  tasks:
+    - name: Include Provider setup tasks
+      include_tasks: roles/provider/tasks/setup.yml
+    - name: Include Provider run tasks
+      include_tasks: roles/provider/tasks/run.yml
+
+- name: Deploy Mix Nodes
+  hosts: mix_nodes
+  become: true
+  vars:
+    base_dir: "/opt/katzenpost"
+    mix_count: "{{ config.mix_count }}"
+    artifacts_dir: "{{ playbook_dir }}/artifacts"
+  strategy: free
+  tasks:
+    - name: Include Mix setup tasks
+      include_tasks: roles/mix/tasks/setup.yml
+    - name: Include Mix run tasks
+      include_tasks: roles/mix/tasks/run.yml

--- a/ansible/playbooks/roles/common/tasks/main.yml
+++ b/ansible/playbooks/roles/common/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: Ensure system is updated
+  ansible.builtin.apt:
+    update_cache: yes
+    cache_valid_time: 3600  # 1 hour
+- name: Install required packages
+  ansible.builtin.apt:
+    name:
+      - ntp
+    state: present
+- name: Ensure base directory exists
+  ansible.builtin.file:
+    path: "/opt/katzenpost"
+    state: directory
+- name: Ensure mixnet pki directory exists
+  ansible.builtin.file:
+    path: "/voting_mixnet"
+    state: directory
+- name: Check if NTP is already synchronized
+  command: timedatectl status
+  register: timedatectl_status
+  failed_when: timedatectl_status.rc != 0
+  changed_when: false
+
+- name: Debug timedatectl output
+  debug:
+    var: timedatectl_status.stdout_lines
+
+- name: Configure NTP if not synchronized
+  block:
+    - name: Configure NTP
+      lineinfile:
+        path: /etc/ntp.conf
+        regexp: "^pool"
+        line: "pool {{ ntp_server }}"
+      loop:
+        - "0.ubuntu.pool.ntp.org"
+        - "1.ubuntu.pool.ntp.org"
+        - "2.ubuntu.pool.ntp.org"
+        - "3.ubuntu.pool.ntp.org"
+      loop_control:
+        loop_var: ntp_server
+
+    - name: Restart NTP service
+      systemd:
+        name: ntp
+        state: restarted
+  when: "'not synchronized' in timedatectl_status.stdout"

--- a/ansible/playbooks/roles/dirauth/tasks/run.yml
+++ b/ansible/playbooks/roles/dirauth/tasks/run.yml
@@ -1,0 +1,52 @@
+---
+- name: Check if mixnet_voting service file exists
+  ansible.builtin.stat:
+    path: "/etc/systemd/system/mixnet_voting.service"
+  register: mixnet_voting_service
+
+- name: Create mixnet_voting service file
+  block:
+    - name: Creating mixnet_voting systemd service file
+      copy:
+        content: |
+          [Unit]
+          Description=Mixnet Voting Service
+          After=network.target
+          
+          [Service]
+          Type=simple
+          User=root
+          WorkingDirectory={{ base_dir }}
+          ExecStart={{ base_dir }}/voting -f {{ base_dir }}/authority.toml
+          Restart=always
+          RestartSec=5
+          
+          [Install]
+          WantedBy=multi-user.target
+        dest: "/etc/systemd/system/mixnet_voting.service"
+  when: not mixnet_voting_service.stat.exists
+
+- name: Reload systemd to recognize mixnet service
+  ansible.builtin.systemd:
+    daemon_reload: yes
+  when: not mixnet_voting_service.stat.exists
+
+- name: Ensure mixnet_voting service is started and enabled
+  ansible.builtin.systemd:
+    name: mixnet_voting
+    state: started
+    enabled: yes
+
+- name: Output systemctl status of mixnet_voting
+  ansible.builtin.shell: systemctl status mixnet_voting
+  register: service_status
+
+- name: Print the registered status output
+  ansible.builtin.debug:
+    var: service_status.stdout
+
+- name: Check if NTP is already synchronized
+  command: timedatectl status
+  register: timedatectl_status
+  failed_when: timedatectl_status.rc != 0
+  changed_when: false

--- a/ansible/playbooks/roles/dirauth/tasks/setup.yml
+++ b/ansible/playbooks/roles/dirauth/tasks/setup.yml
@@ -1,0 +1,40 @@
+---
+- name: Copy Authority voting binary to node
+  copy:
+    src: "{{ artifacts_dir }}/bin/voting"
+    dest: "{{ base_dir }}/voting"
+    mode: '0755'
+
+- name: Copy Authority configuration to node
+  copy:
+    src: "{{ artifacts_dir }}/voting_mixnet/auth{{ ansible_play_batch.index(inventory_hostname) + 1 }}/authority.toml"
+    dest: "{{ base_dir }}/authority.toml"
+
+- name: Replace ansible_host IP address with 127.0.0.1 in authority.toml using sed
+  ansible.builtin.shell: "sed -i 's/{{ ansible_host }}/127.0.0.1/g' {{ base_dir }}/authority.toml"
+  args:
+    executable: /bin/bash
+
+- name: Copy recursively mixnet_pki dir to base_dir/mixnet_pki
+  copy:
+    src: "{{ artifacts_dir }}/mixnet_pki/"
+    dest: "/voting_mixnet"
+
+- name: Set permissions for voting_mixnet directories
+  file:
+    path: "/voting_mixnet"
+    state: directory
+    mode: "0700"
+    recurse: yes
+
+- name: Copy identity private key to node
+  copy:
+    src: "{{ artifacts_dir }}/voting_mixnet/auth{{ ansible_play_batch.index(inventory_hostname) + 1 }}/identity.private.pem"
+    dest: "/voting_mixnet/auth{{ ansible_play_batch.index(inventory_hostname) + 1 }}/identity.private.pem"
+    mode: '0600'
+
+- name: Copy link private key to node
+  copy:
+    src: "{{ artifacts_dir }}/voting_mixnet/auth{{ ansible_play_batch.index(inventory_hostname) + 1 }}/link.private.pem"
+    dest: "/voting_mixnet/auth{{ ansible_play_batch.index(inventory_hostname) + 1 }}/link.private.pem"
+    mode: '0600'

--- a/ansible/playbooks/roles/mix/tasks/run.yml
+++ b/ansible/playbooks/roles/mix/tasks/run.yml
@@ -1,0 +1,52 @@
+---
+- name: Check if mixnet_mix service file exists
+  ansible.builtin.stat:
+    path: "/etc/systemd/system/mixnet_mix.service"
+  register: mixnet_mix_service
+
+- name: Create mixnet_mix service file
+  block:
+    - name: Creating mixnet_mix systemd service file
+      copy:
+        content: |
+          [Unit]
+          Description=Mixnet Mix Service
+          After=network.target
+          
+          [Service]
+          Type=simple
+          User=root
+          WorkingDirectory={{ base_dir }}
+          ExecStart={{ base_dir }}/server -f {{ base_dir }}/katzenpost.toml
+          Restart=always
+          RestartSec=5
+          
+          [Install]
+          WantedBy=multi-user.target
+        dest: "/etc/systemd/system/mixnet_mix.service"
+  when: not mixnet_mix_service.stat.exists
+
+- name: Reload systemd to recognize mixnet service
+  ansible.builtin.systemd:
+    daemon_reload: yes
+  when: not mixnet_mix_service.stat.exists
+
+- name: Ensure mixnet_mix service is started and enabled
+  ansible.builtin.systemd:
+    name: mixnet_mix
+    state: started
+    enabled: yes
+
+- name: Output systemctl status of mixnet_mix
+  ansible.builtin.shell: systemctl status mixnet_mix
+  register: service_status
+
+- name: Print the registered status output
+  ansible.builtin.debug:
+    var: service_status.stdout
+
+- name: Check if NTP is already synchronized
+  command: timedatectl status
+  register: timedatectl_status
+  failed_when: timedatectl_status.rc != 0
+  changed_when: false

--- a/ansible/playbooks/roles/mix/tasks/setup.yml
+++ b/ansible/playbooks/roles/mix/tasks/setup.yml
@@ -1,0 +1,16 @@
+---
+- name: Copy server server binary to node
+  copy:
+    src: "{{ artifacts_dir }}/bin/server"
+    dest: "{{ base_dir }}/server"
+    mode: '0755'
+
+- name: Copy katzenpost configuration to node
+  copy:
+    src: "{{ artifacts_dir }}/voting_mixnet/mix{{ ansible_play_batch.index(inventory_hostname) + 1 }}/katzenpost.toml"
+    dest: "{{ base_dir }}/katzenpost.toml"
+
+- name: Replace ansible_host IP address with 127.0.0.1 in authority.toml using sed
+  ansible.builtin.shell: "sed -i 's/{{ ansible_host }}/127.0.0.1/g' {{ base_dir }}/katzenpost.toml"
+  args:
+    executable: /bin/bash

--- a/ansible/playbooks/roles/provider/tasks/run.yml
+++ b/ansible/playbooks/roles/provider/tasks/run.yml
@@ -1,0 +1,52 @@
+---
+- name: Check if provider service file exists
+  ansible.builtin.stat:
+    path: "/etc/systemd/system/provider.service"
+  register: provider_service
+
+- name: Create provider service file
+  block:
+    - name: Creating provider systemd service file
+      copy:
+        content: |
+          [Unit]
+          Description=Provider Service
+          After=network.target
+          
+          [Service]
+          Type=simple
+          User=root
+          WorkingDirectory={{ base_dir }}
+          ExecStart={{ base_dir }}/server -f {{ base_dir }}/katzenpost.toml
+          Restart=always
+          RestartSec=5
+          
+          [Install]
+          WantedBy=multi-user.target
+        dest: "/etc/systemd/system/provider.service"
+  when: not provider_service.stat.exists
+
+- name: Reload systemd to recognize mixnet service
+  ansible.builtin.systemd:
+    daemon_reload: yes
+  when: not provider_service.stat.exists
+
+- name: Ensure provider service is started and enabled
+  ansible.builtin.systemd:
+    name: provider
+    state: started
+    enabled: yes
+
+- name: Output systemctl status of provider
+  ansible.builtin.shell: systemctl status provider
+  register: service_status
+
+- name: Print the registered status output
+  ansible.builtin.debug:
+    var: service_status.stdout
+
+- name: Check if NTP is already synchronized
+  command: timedatectl status
+  register: timedatectl_status
+  failed_when: timedatectl_status.rc != 0
+  changed_when: false

--- a/ansible/playbooks/roles/provider/tasks/setup.yml
+++ b/ansible/playbooks/roles/provider/tasks/setup.yml
@@ -1,0 +1,29 @@
+---
+- name: Copy Authority server binary to node
+  copy:
+    src: "{{ artifacts_dir }}/bin/server"
+    dest: "{{ base_dir }}/server"
+    mode: '0755'
+
+- name: copy memspool binary to node
+  copy:
+    src: "{{ artifacts_dir }}/bin/memspool"
+    dest: "/voting_mixnet/memspool"
+    mode: '0755'
+
+- name: copy panda_server binary to node
+  copy:
+    src: "{{ artifacts_dir }}/bin/panda_server"
+    dest: "/voting_mixnet/panda_server"
+    mode: '0755'
+
+- name: Copy Authority configuration to node
+  copy:
+    src: "{{ artifacts_dir }}/voting_mixnet/provider{{ ansible_play_batch.index(inventory_hostname) + 1 }}/katzenpost.toml"
+    dest: "{{ base_dir }}/katzenpost.toml"
+
+- name: Replace ansible_host IP address with 127.0.0.1 in authority.toml using sed
+  ansible.builtin.shell: "sed -i 's/{{ ansible_host }}/127.0.0.1/g' {{ base_dir }}/katzenpost.toml"
+  args:
+    executable: /bin/bash
+

--- a/ansible/run_playbook.sh
+++ b/ansible/run_playbook.sh
@@ -1,0 +1,16 @@
+
+#brew install ansible
+
+
+#chmod 400 katzenpost-ansible.pem
+#ssh -i "katzenpost-ansible.pem" ubuntu@100.24.67.47
+export ANSIBLE_HOST_KEY_CHECKING=False
+
+###### build mix_net #####
+#ansible-playbook -i hosts_builder.ini playbooks/build_and_configure.yml
+
+##### deploy mix_net #####
+ansible-playbook -i hosts_mixnet.ini playbooks/deploy_mixnet.yml
+
+#### clear artifacts ####
+rm -rf playbooks/artifacts

--- a/ansible/scripts/update_address.py
+++ b/ansible/scripts/update_address.py
@@ -1,0 +1,79 @@
+import os
+from configparser import ConfigParser
+
+port = 8080
+
+# Define the path to the directory containing the TOML files
+directory_path = "voting_mixnet"
+
+# Define the path to the hosts_mixnet.ini file
+hosts_mixnet_path = "hosts_mixnet.ini"
+
+# Parse the hosts_mixnet.ini to get new addresses
+config = ConfigParser()
+config.read(hosts_mixnet_path)
+
+new_addresses = {}
+for section in config.sections():
+    addr = []
+    for key, value in config.items(section):
+        ip = key.split(" ")[0]
+        new_address = f"{ip}:{port}"
+        addr.append(new_address)
+    new_addresses[section] = addr
+
+
+# Initialize starting port and address_mapping
+default_address = "127.0.0.1"
+start_port = 30001
+address_mapping = {}
+
+# dirauth_nodes
+for address in new_addresses['dirauth_nodes']:
+    old_address = f"{default_address}:{start_port}"
+    address_mapping[old_address] = address
+    start_port += 1  # Increment by 1 for dirauth_nodes
+
+# provider_nodes
+for i, address in enumerate(new_addresses['provider_nodes']):
+    # Main service port
+    old_address = f"{default_address}:{start_port}"
+    address_mapping[old_address] = address
+    start_port += 1  # Increment to skip to the metrics port
+    # Metrics port, skipped in mapping, just increment start_port
+    old_metrics_address = f"{default_address}:{start_port}"
+    address_mapping[old_metrics_address] = old_metrics_address
+    start_port += 1
+
+# mix_nodes
+for i, address in enumerate(new_addresses['mix_nodes']):
+    # Main service port
+    old_address = f"{default_address}:{start_port}"
+    address_mapping[old_address] = address
+    start_port += 1  # Increment to skip to the metrics port
+
+    old_metrics_address = f"{default_address}:{start_port}"
+    address_mapping[old_metrics_address] = old_metrics_address
+    start_port += 1
+
+
+
+# Function to update all .toml files in a directory
+def update_toml_files(directory_path, address_mapping):
+    for root, dirs, files in os.walk(directory_path):
+        for name in files:
+            if name.endswith(".toml"):
+                file_path = os.path.join(root, name)
+                with open(file_path, 'r') as file:
+                    file_contents = file.read()
+
+                # Replace all occurrences of each address
+                for old_address, new_address in address_mapping.items():
+                    file_contents = file_contents.replace(old_address, new_address)
+
+                # Write the updated contents back to the file
+                with open(file_path, 'w') as file:
+                    file.write(file_contents)
+
+# Update all .toml files
+update_toml_files(directory_path, address_mapping)


### PR DESCRIPTION
PR from @amitbasuri

> This Pull Request (PR) introduces essential configurations and scripts to automate the setup and management of a small Katzenpost mixnet infrastructure using Ansible. The aim is to enable DevOps to efficiently operate and scale the mixnet by automating the provisioning, configuration, and management processes. The proposed setup includes a minimum configuration of 8 nodes divided into 3 mix nodes, 2 provider nodes, and 3 directory authority (dirauth) nodes, ensuring a robust and fault-tolerant network.

